### PR TITLE
chg: update flux APIs to version v1 for 2.6 

### DIFF
--- a/flux-modules/cilium/kustomization-cilium-post.yaml
+++ b/flux-modules/cilium/kustomization-cilium-post.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cilium-post-deploy

--- a/flux-modules/cilium/kustomization-cilium.yaml
+++ b/flux-modules/cilium/kustomization-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cilium

--- a/flux-modules/extras/mariadb/kustomization-mariadb-pre.yaml
+++ b/flux-modules/extras/mariadb/kustomization-mariadb-pre.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: mariadb-pre-deploy

--- a/flux-modules/extras/mariadb/kustomization-mariadb.yaml
+++ b/flux-modules/extras/mariadb/kustomization-mariadb.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: mariadb

--- a/flux-modules/extras/paperless/kustomization-paperless-pre.yaml
+++ b/flux-modules/extras/paperless/kustomization-paperless-pre.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: paperless-pre-deploy

--- a/flux-modules/extras/paperless/kustomization-paperless.yaml
+++ b/flux-modules/extras/paperless/kustomization-paperless.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: paperless

--- a/flux-modules/extras/wireguard/kustomization-wireguard-pre.yaml
+++ b/flux-modules/extras/wireguard/kustomization-wireguard-pre.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: wireguard-pre-deploy

--- a/flux-modules/extras/wireguard/kustomization-wireguard.yaml
+++ b/flux-modules/extras/wireguard/kustomization-wireguard.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: wireguard

--- a/flux-modules/extras/wordpress/deploy/bitnami-wordpress-helmrepo.yaml
+++ b/flux-modules/extras/wordpress/deploy/bitnami-wordpress-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: bitnami-wordpress

--- a/flux-modules/extras/wordpress/kustomization-wordpress-pre.yaml
+++ b/flux-modules/extras/wordpress/kustomization-wordpress-pre.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: wordpress-${wp_name}-pre-deploy

--- a/flux-modules/extras/wordpress/kustomization-wordpress.yaml
+++ b/flux-modules/extras/wordpress/kustomization-wordpress.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: wordpress-${wp_name}-deploy

--- a/flux-modules/flux-system-extra/flux-notifications.yaml
+++ b/flux-modules/flux-system-extra/flux-notifications.yaml
@@ -1,4 +1,4 @@
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: slack
@@ -9,7 +9,7 @@ spec:
   secretRef:
     name: slack-flux-notification-url
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: alertmanager
@@ -18,7 +18,7 @@ spec:
   type: alertmanager
   address: http://kube-prometheus-stack-alertmanager.kube-system.svc:9093/
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: default-catchall

--- a/flux-modules/flux-system-extra/github-commit-notification.yaml
+++ b/flux-modules/flux-system-extra/github-commit-notification.yaml
@@ -1,4 +1,4 @@
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: oci-infra-repo
@@ -10,7 +10,7 @@ spec:
   secretRef:
     name: github-api-token
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: flux-system-kustomization

--- a/flux-modules/flux-system-extra/kustomization-flux-system-extra.yaml
+++ b/flux-modules/flux-system-extra/kustomization-flux-system-extra.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-system-extra

--- a/flux-modules/flux-system-extra/monitoring/flux-gitrepo.yaml
+++ b/flux-modules/flux-system-extra/monitoring/flux-gitrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: flux-monitoring

--- a/flux-modules/flux-system-extra/monitoring/flux-monitoring-config-kustomization.yaml
+++ b/flux-modules/flux-system-extra/monitoring/flux-monitoring-config-kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: monitoring-config

--- a/flux-modules/flux-system-extra/monitoring/kustomization-monitoring-flux.yaml
+++ b/flux-modules/flux-system-extra/monitoring/kustomization-monitoring-flux.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-monitoring
@@ -21,7 +21,7 @@ spec:
     - target:
         kind: Kustomization
         group: kustomize.toolkit.fluxcd.io
-        version: v1beta2
+        version: v1
         name: monitoring-flux
       patch: |-
         - op: replace

--- a/flux-modules/kube-system-extra/kustomization-kube-system-extra.yaml
+++ b/flux-modules/kube-system-extra/kustomization-kube-system-extra.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kube-system-extra

--- a/flux-modules/kube-system/kustomization-kube-system.yaml
+++ b/flux-modules/kube-system/kustomization-kube-system.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kube-system

--- a/flux-modules/loki/kustomization-loki.yaml
+++ b/flux-modules/loki/kustomization-loki.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: loki

--- a/flux-modules/monitoring/kube-prometheus-stack.yaml
+++ b/flux-modules/monitoring/kube-prometheus-stack.yaml
@@ -208,7 +208,7 @@ spec:
                       source_name: [spec, sourceRef, name]
               - groupVersionKind:
                   group: helm.toolkit.fluxcd.io
-                  version: v2beta2
+                  version: v2
                   kind: HelmRelease
                 metricNamePrefix: gotk
                 metrics:
@@ -247,7 +247,7 @@ spec:
                       url: [spec, url]
               - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: v1beta2
+                  version: v1
                   kind: Bucket
                 metricNamePrefix: gotk
                 metrics:
@@ -267,7 +267,7 @@ spec:
                       bucket_name: [spec, bucketName]
               - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: v1beta2
+                  version: v1
                   kind: HelmRepository
                 metricNamePrefix: gotk
                 metrics:
@@ -286,7 +286,7 @@ spec:
                       url: [spec, url]
               - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: v1beta2
+                  version: v1
                   kind: HelmChart
                 metricNamePrefix: gotk
                 metrics:
@@ -306,7 +306,7 @@ spec:
                       chart_version: [spec, version]
               - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: v1beta2
+                  version: v1
                   kind: OCIRepository
                 metricNamePrefix: gotk
                 metrics:
@@ -411,7 +411,7 @@ spec:
                       source_name: [spec, imageRepositoryRef, name]
               - groupVersionKind:
                   group: image.toolkit.fluxcd.io
-                  version: v1beta1
+                  version: v1beta2
                   kind: ImageUpdateAutomation
                 metricNamePrefix: gotk
                 metrics:

--- a/flux-modules/monitoring/kustomization-monitoring.yaml
+++ b/flux-modules/monitoring/kustomization-monitoring.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: monitoring

--- a/flux/extras/wordpress-template/kustomization-wordpress.yaml
+++ b/flux/extras/wordpress-template/kustomization-wordpress.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: wordpress-template


### PR DESCRIPTION
Flux 2.6 and up graduated some APIs, this PR does a migration to cover that.